### PR TITLE
Update search url format

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -260,7 +260,7 @@ function onScriptsLoaded() {
     if (text.match(/^https?\:/)) {
       navigateToUrl(text);
     } else {
-      navigateToUrl('https://developer.android.com/index.html#q=' +
+      navigateToUrl('https://developer.android.com/index.html?q=' +
           encodeURIComponent(text));
     }
   });


### PR DESCRIPTION
Looks like the developer site changed the token for a search. Not the most knowledgeable here, so this may not be all the cases where we navigate to a search url (sorry if it isn't).

Currently the plugin will navigate to https://developer.android.com/index.html#q=fragment which does not trigger the search, where as https://developer.android.com/index.html?q=fragment will.