### PR TITLE
manifest.json: Remove content security policy

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,6 @@
   "name": "Android SDK Search",
   "description": "Adds an 'ad' omnibox command and view source links for the Android SDK.",
   "version": "0.3.15",
-  "content_security_policy": "script-src 'self' https://developer.android.com; object-src 'self'",
   "permissions": [
     "tabs",
     "*://developer.android.com/*",


### PR DESCRIPTION
The custom CSP doesn't seem to be needed and the Mozilla add-on reviewers flag this as allowing remote-script injection.